### PR TITLE
Start processes from a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ _Synchronously_ sets the specified configuration (config) for the forever module
 Starts a script with forever.
 
 ### forever.startDaemon (file, options)
-Starts a script with forever as a daemon. WARNING: Will daemonize the current process.
+Starts a script with forever as a daemon. WARNING: Will daemonize the current process. `file` field can be ommited when `options.command` is set.
 
 ### forever.stop (index)
 Stops the forever daemon script at the specified index. These indices are the same as those returned by forever.list(). This method returns an EventEmitter that raises the 'stop' event when complete.

--- a/bin/monitor
+++ b/bin/monitor
@@ -33,19 +33,19 @@ function start(options) {
     // would still be running in the background unaffected.
     //
     forever.startServer(monitor);
-    
+
     //
     // Disconnect the IPC channel, letting this monitor's parent process know
     // that the child has started successfully.
     //
     process.disconnect();
-    
+
     //
     // Write the pidFile to disk
     //
     writePid(options.pidFile, monitor.child.pid);
   });
-  
+
   //
   // When the monitor restarts update the pid in the pidFile
   //
@@ -64,7 +64,36 @@ function start(options) {
     catch(e){}
   }
   monitor.on('stop', cleanUp);
-  monitor.on('exit', cleanUp);
+  monitor.on('exit', function()
+  {
+    cleanUp()
+
+    // Start fallback command
+    var onexit = options.onexit
+    if(onexit)
+    {
+      var env = options.env || {}
+
+      // Service has a environment defined, override current process.env
+      if(onexit.env)
+        onexit.env.__proto__ = env
+
+      // Service has not defined an environment, use current process.env
+      else
+        onexit.env = env;
+
+      onexit.stdio = onexit.stdio || options.stdio
+
+      onexit.uid     = onexit.uid     || options.uid
+      onexit.logFile = onexit.logFile || options.logFile
+      onexit.pidFile = onexit.pidFile || options.pidFile
+
+      // Start service
+      console.log(onexit)
+      var child = forever.startDaemon(onexit)
+      console.log(child)
+    }
+  });
 }
 
 //

--- a/bin/starter
+++ b/bin/starter
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+var resolve = require('path').resolve
+
+var forever = require('..')
+
+
+// Get path of configuration file. By default, search on the user's $HOME
+var servicesPath;
+if(process.argv.length > 2)
+  servicesPath = process.argv[2]
+else
+  servicesPath = resolve(process.env.HOME, 'etc', 'forever-starter.json')
+
+
+// Load configuration file
+var services;
+try
+{
+  services = require(servicesPath)
+}
+catch(exception)
+{
+  console.error(exception)
+  process.exit(-1)
+}
+
+
+// Start services
+services.forEach(function(service)
+{
+  if(typeof service == 'string')
+    service =
+    {
+      command: service,
+      enabled: true
+    };
+
+  if(service.enabled)
+  {
+    // Service has a environment defined, override current process.env with them
+    if(service.env)
+    {
+      var keys = Object.keys(service.env)
+
+      for(var key in process.env)
+        if(keys.indexOf(key) == -1)
+          service.env[key] = process.env[key];
+    }
+
+    // Service has not defined an environment, use current process.env
+    else
+      service.env = process.env;
+
+    // Start service
+    forever.startDaemon(service)
+  }
+})

--- a/bin/starter
+++ b/bin/starter
@@ -38,15 +38,9 @@ services.forEach(function(service)
 
   if(service.enabled)
   {
-    // Service has a environment defined, override current process.env with them
+    // Service has a environment defined, override current process.env
     if(service.env)
-    {
-      var keys = Object.keys(service.env)
-
-      for(var key in process.env)
-        if(keys.indexOf(key) == -1)
-          service.env[key] = process.env[key];
-    }
+      service.env.__proto__ = process.env
 
     // Service has not defined an environment, use current process.env
     else

--- a/lib/forever.js
+++ b/lib/forever.js
@@ -384,6 +384,15 @@ forever.start = function (script, options) {
 // Starts a script with forever as a daemon
 //
 forever.startDaemon = function (script, options) {
+  if (script && !Array.isArray(script) && typeof script != 'string') {
+    options = script;
+    script = undefined;
+  }
+
+  if (!script && !(options && options.command)) {
+    throw new SyntaxError("One of 'script' or 'options.command' fields must be defined")
+  }
+
   options         = options || {};
   options.uid     = options.uid || utile.randomString(4).replace(/^\-/, '_');
   options.logFile = forever.logFilePath(options.logFile || forever.config.get('logFile') || options.uid + '.log');
@@ -399,9 +408,11 @@ forever.startDaemon = function (script, options) {
   //
   outFD = fs.openSync(options.logFile, 'a');
   errFD = fs.openSync(options.logFile, 'a');
-  monitorPath = path.resolve(__dirname, '..', 'bin', 'monitor');
 
-  monitor = spawn(process.execPath, [monitorPath, script], {
+  var args = [path.resolve(__dirname, '..', 'bin', 'monitor')];
+  if(script) args.push(script);
+
+  monitor = spawn(process.execPath, args, {
     stdio: ['ipc', outFD, errFD],
     detached: true
   });

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "vows": "0.7.x"
   },
   "bin": {
-    "forever": "./bin/forever"
+    "forever": "bin/forever",
+    "forever-starter": "bin/starter"
   },
   "main": "./lib/forever",
   "scripts": {


### PR DESCRIPTION
This define a helper command that load a JSON file and start the commands defined there using ```forever```. The format of the JSON file is an array of objects, being this ones the same format of the ```options``` field of the ```forever.Monitor``` object defined in ```forever-monitor``` project, with the only difference of an ```enabled``` field that when it's not defined or it's falsy allow to define a command on this JSON file but don't exec it.

This pull-request requires of https://github.com/nodejitsu/forever/pull/599.