### PR TITLE
--killSignal description enhanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You can use forever to run any kind of script continuously (whether it is writte
     --watchIgnore    To ignore pattern when watch is enabled (multiple option is allowed)
     --killSignal     Support exit signal customization (default is SIGKILL),
                      used for restarting script gracefully eg. --killSignal=SIGTERM
+                     Any console output generated after calling forever stop/stopall will not appear in the logs
     -h, --help       You're staring at it
 
   [Long Running Process]

--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -67,6 +67,7 @@ var help = [
   '  --watchIgnore    To ignore pattern when watch is enabled (multiple option is allowed)',
   '  --killSignal     Support exit signal customization (default is SIGKILL)',
   '                   used for restarting script gracefully eg. --killSignal=SIGTERM',
+  '                   Any console output generated after calling forever stop/stopall will not appear in the logs',
   '  -h, --help       You\'re staring at it',
   '',
   '[Long Running Process]',


### PR DESCRIPTION
Added information about the fact that no output is appended to the logs after forever stop/stopall is called.

Consider this:

```
process.on('SIGINT', function() {
   console.log("SIGINT invoked");
});
```

When the script is started with `forever start script.js --killSignal=SIGINT` the function will be invoked but "SIGINT invoked" will not appear in the log file.

This might result in endless debugging which I hope to prevent with the enhanced description about the `--killSignal` option.
