### PR TITLE
[doc] Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# forever [![Build Status](https://api.travis-ci.org/foreverjs/forever.svg)](https://travis-ci.org/foreverjs/forever)
+# forever [![Build Status](https://api.travis-ci.org/foreverjs/forever.svg)](https://travis-ci.org/foreverjs/forever) [![Inline docs](http://inch-ci.org/github/foreverjs/forever.svg?branch=master)](http://inch-ci.org/github/foreverjs/forever)
 
 A simple CLI tool for ensuring that a given script runs continuously (i.e. forever).
 


### PR DESCRIPTION
Hi there,

I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/foreverjs/forever.svg)](http://inch-ci.org/github/foreverjs/forever)

The badge links to [Inch CI](http://inch-ci.org) and shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs in Open Source to encourage aspiring programmers to document their code. So far over 500 **Ruby** projects are sporting these badges to raise awareness for the importance of inline-docs and to show potential contributors that they can expect a certain level of code documentation when they dive into your code.

I would really like to do the same for the **JavaScript** community and roll out support for JS over the coming weeks. Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/foreverjs/forever

What do you think?