### PR TITLE
Fix "error: Forever detected script exited with code: null"

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -972,7 +972,7 @@ forever.logEvents = function (monitor) {
   });
 
   monitor.on('exit:code', function (code, signal) {
-    forever.out.error(!isNaN(code)
+    forever.out.error((code !== null && code !== undefined)
       ? 'Forever detected script exited with code: ' + code
       : 'Forever detected script was killed by signal: ' + signal);
   });


### PR DESCRIPTION
When a process dies from a signal and has no exit code, forever logs this incorrectly.  It is checking isNaN(code), which is wrong.  isNaN(x) does not check that x is numeric; it merely checks if x is equal to NaN; since code is either null or an integer, this can never be true in this context.  isNaN(null) === false.

This patch corrects this bad check, to verify that code was in fact passed by the exit handler.  If it wasn't, then we fall through to print the signal that killed the monitored process.