### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
   },
   "engines": {
     "node": ">= 0.8.x"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/