### PR TITLE
Relative log file path

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -938,7 +938,11 @@ forever.cleanLogsSync = function (processes) {
 // Determines the full logfile path name
 //
 forever.logFilePath = function (logFile, uid) {
-  return logFile && (logFile[0] === '/' || logFile[1] === ':')
+  return logFile && (
+    logFile[0] === '/' || 
+    logFile[1] === ':' || 
+    logFile.substring(0, 2) === "./" || 
+    logFile.substring(0, 3) === "../")
     ? logFile
     : path.join(forever.config.get('root'), logFile || (uid || 'forever') + '.log');
 };


### PR DESCRIPTION
Relative log path is created when log file argument is prefixed with ./ or ../