### PR TITLE
Fix findById which was using double rather than triple equals operator

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -681,7 +681,7 @@ forever.tail = function (target, options, callback) {
 
 //
 // ### function findById (id, processes)
-// #### @index {string} Index of the process to find.
+// #### @id {string} id of the process to find.
 // #### @processes {Array} Set of processes to find in.
 // Finds the process with the specified index.
 //
@@ -689,7 +689,7 @@ forever.findById = function (id, processes) {
   if (!processes) { return null; }
 
   var procs = processes.filter(function (p) {
-    return p.id == id;
+    return p.id === id;
   });
 
   if (procs.length === 0) { procs = null; }


### PR DESCRIPTION
As title, this hopefully allows findById to work correctly and fixes #699 (forever stop id seems to stop all processes).

I've not been able to run the "npm test" suite - i've filed #755 for this.

Of course I have tested this on our local build machine and now undeploying the first test environment to be setup on the machine (i.e. has a forever process as index 0) now no longer kills every nodejs process (i.e. evey test environment) on the same box.