### PR TITLE
The logs command doesn't recognize slashes in script path. It should.

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -499,7 +499,7 @@ app.cmd('clear :key', cli.clear = function (key) {
 // #### @target {string} Target script or index to list logs for
 // Displays the logs using `tail` for the specified `target`.
 //
-app.cmd('logs :index', cli.logs = function (index) {
+app.cmd(/logs (.+)/, cli.logs = function (index) {
   var options = {
       stream: app.argv.fifo,
       length: app.argv.number


### PR DESCRIPTION
I often start my node servers using absolute path, like:
```
forever start /var/www/foo/bar/app.js
```

But the logs command doesn't recognize slashes in the script path, and this fails:
```
forever logs /var/www/foo/bar/app.js
```

This patch should fix this problem