### PR TITLE
Replacing four process.nextTick calls with four setImmediate calls. S…

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -218,7 +218,7 @@ function stopOrRestart(action, event, format, target) {
 
   getAllProcesses(function (err, processes) {
     if (err) {
-      return process.nextTick(function () {
+      return setImmediate(function () {
         emitter.emit('error', err);
       });
     }
@@ -251,7 +251,7 @@ function stopOrRestart(action, event, format, target) {
       });
     }
     else {
-      process.nextTick(function () {
+      setImmediate(function () {
         emitter.emit('error', new Error('Cannot find forever process: ' + target));
       });
     }
@@ -827,7 +827,7 @@ forever.cleanUp = function (cleanLogs, allowManager) {
 
   getAllProcesses(function (err, processes) {
     if (err) {
-      return process.nextTick(function () {
+      return setImmediate(function () {
         emitter.emit('error', err);
       });
     }
@@ -896,7 +896,7 @@ forever.cleanUp = function (cleanLogs, allowManager) {
       })(processes.splice(0, 10));
     }
     else {
-      process.nextTick(function () {
+      setImmediate(function () {
         emitter.emit('cleanUp');
       });
     }


### PR DESCRIPTION
Response to https://github.com/foreverjs/forever/issues/715

The process.nextTick deprecation warnings are causing problems on one of my servers. This appears to resolve those problems. Two tests were broken pre-commit, and those two tests are still broken, but no more have broken.