### PR TITLE
fix warnings when values set in .json file: minUptime and spinSleepTime

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -263,12 +263,12 @@ var getOptions = cli.getOptions = function (file) {
     ? options.watchIgnore
     : [options.watchIgnore];
 
-  if (!options.minUptime) {
+  if (!options.minUptime && ~configs.indexOf("minUptime")) {
     forever.log.warn('--minUptime not set. Defaulting to: 1000ms');
     options.minUptime = 1000;
   }
 
-  if (!options.spinSleepTime) {
+  if (!options.spinSleepTime && ~configs.indexOf("spinSleepTime")) {
     forever.log.warn([
       '--spinSleepTime not set. Your script',
       'will exit if it does not stay up for',


### PR DESCRIPTION
Warnings are thrown during getOptions if minUptime and/or spinSleepTime are not set as CLI arguments. If these parameters are defined in a .json config file, the program flow first checks for the CLI argument, throws  the warning and then sets the options based on the .json parameters. This is a simple fix to the if statement which also checks if these parameters are set in the .json file.