### PR TITLE
fix to spawn app in each workingDir or sourcDir

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -314,6 +314,9 @@ app.cmd(/start (.+)/, cli.startDaemon = function () {
       options = getOptions(file);
 
   options.forEach(function (o) {
+    
+    o.spawnWith.cwd = o.workingDir || o.sourceDir || o.spawnWith.cwd;
+    
     forever.log.info('Forever processing file: ' + o.script.grey);
     tryStart(o.script, o, function () {
       forever.startDaemon(o.script, o);


### PR DESCRIPTION
fix to use json config file's workingDir or sourceDir if available for spawning