### PR TITLE
Use update version of forever-monitor that uses version of minimatch …

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clone": "^1.0.2",
     "colors": "~0.6.2",
     "flatiron": "~0.4.2",
-    "forever-monitor": "~1.6.0",
+    "forever-monitor": "~1.7.0",
     "nconf": "~0.6.9",
     "nssocket": "~0.5.1",
     "object-assign": "^3.0.0",


### PR DESCRIPTION
…that does not present warning. See https://github.com/foreverjs/forever-monitor/issues/130 and https://github.com/foreverjs/forever/issues/858