### PR TITLE
resolve reDoS vulnerability; update to latest forever-monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clone": "^1.0.2",
     "colors": "~0.6.2",
     "flatiron": "~0.4.2",
-    "forever-monitor": "~1.6.0",
+    "forever-monitor": "^1.7.0",
     "nconf": "~0.6.9",
     "nssocket": "~0.5.1",
     "object-assign": "^3.0.0",


### PR DESCRIPTION
```
? High severity vuln found in minimatch@2.0.10, introduced via findup-sync@0.2.1
- desc: Regular Expression Denial of Service
- info: https://snyk.io/vuln/npm:minimatch:20160620
- from: findup-sync@0.2.1 > glob@4.3.5 > minimatch@2.0.10
```

This was resolved in `forever-monitor` but `forever` is not resolving to this version; see https://github.com/foreverjs/forever-monitor/commit/de4e2a28de18d38992657d676f32931e45d56d67
