### PR TITLE
Small fix in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A simple CLI tool for ensuring that a given script runs continuously (i.e. forev
 
 ``` bash
   $ cd /path/to/your/project
-  $ [sudo] npm install forever-monitor
+  $ npm install forever-monitor
 ```
 
 ## Usage


### PR DESCRIPTION
There is no necessity to have `root` permissions to install a npm package to a local project, this is also a very common bad practice.
So I am just removing the `[sudo]`, because it can mislead users to do it.