### PR TITLE
[dist] update forever-monitor to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "forever",
   "preferGlobal": "true",
   "description": "A simple CLI tool for ensuring that a given node script runs continuously (i.e. forever)",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "maintainers": [
     "mmalecki <me@mmalecki.com>",
@@ -23,7 +23,7 @@
     "clone": "^1.0.2",
     "colors": "~0.6.2",
     "flatiron": "~0.4.2",
-    "forever-monitor": "~1.6.0",
+    "forever-monitor": "~1.7.0",
     "nconf": "~0.6.9",
     "nssocket": "~0.5.1",
     "object-assign": "^3.0.0",


### PR DESCRIPTION
Update forever-monitor to latest version: Updates forever-monitor dependency minimatch
to 3.0.3. This is necessary to avoid a RegExp DoS issue.