### PR TITLE
bump forever-monitor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clone": "^1.0.2",
     "colors": "~0.6.2",
     "flatiron": "~0.4.2",
-    "forever-monitor": "~1.6.0",
+    "forever-monitor": "~1.7.0",
     "nconf": "~0.6.9",
     "nssocket": "~0.5.1",
     "object-assign": "^3.0.0",


### PR DESCRIPTION
Warning message when installing forever: "minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue"

forever-monitor@1.6.0 requests minimatch@2.0.10 which is deprecated
forever-monitor@1.7.0 requests minimatch@3.0.2

Thanks