### PR TITLE
Add dir column by default on "forever list"

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -305,7 +305,7 @@ forever.load = function (options) {
   options.columns  = options.columns  || forever.config.get('columns');
   if (!options.columns) {
     options.columns = [
-      'uid', 'command', 'script', 'forever', 'pid', 'id', 'logfile', 'uptime'
+      'uid', 'command', 'dir', 'script', 'forever', 'pid', 'id', 'logfile', 'uptime'
     ];
   }
 


### PR DESCRIPTION
This adds the "dir" column by default when issuing the "forever list" command. It is the only field that can help the user to determine which PID is running but it is hidden by default!

I know that it is possible to add an UID, however if the UID is added to the start command in the _package.json_ then it will be commited in GIT, thus not allowing the user to know if is a dev or a prod deployment.