### PR TITLE
Removed dependency on timespan

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -14,7 +14,7 @@ var fs = require('fs'),
     cliff = require('cliff'),
     nconf = require('nconf'),
     nssocket = require('nssocket'),
-    timespan = require('timespan'),
+    dateDifference = require('date-difference'),
     utile = require('utile'),
     winston = require('winston'),
     mkdirp = utile.mkdirp,
@@ -1037,7 +1037,7 @@ forever.columns = {
   uptime: {
     color: 'yellow',
     get: function (proc) {
-      return proc.running ? timespan.fromDates(new Date(proc.ctime), new Date()).toString().yellow : "STOPPED".red;
+      return proc.running ? dateDifference(new Date(proc.ctime), new Date()).yellow : "STOPPED".red;
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cliff": "~0.1.9",
     "clone": "^1.0.2",
     "colors": "~0.6.2",
+    "date-difference": "^1.0.0",
     "flatiron": "~0.4.2",
     "forever-monitor": "~1.7.0",
     "nconf": "~0.6.9",
@@ -31,7 +32,6 @@
     "path-is-absolute": "~1.0.0",
     "prettyjson": "^1.1.2",
     "shush": "^1.0.0",
-    "timespan": "~2.3.0",
     "utile": "~0.2.1",
     "winston": "~0.8.1"
   },


### PR DESCRIPTION
Will change the display of uptime from:
38d 16h 1m 23s
into
38:16:1:23.49

See https://nodesecurity.io/advisories/533

See #955