### PR TITLE
[fix] use fs.unlinkSync

### DIFF
--- a/lib/forever/worker.js
+++ b/lib/forever/worker.js
@@ -93,7 +93,7 @@ Worker.prototype.start = function (callback) {
         // as a mapping to the `\\.pipe\\*` "files" that can't
         // be enumerated because ... Windows.
         //
-        fs.unlink(self._sockFile);
+        fs.unlinkSync(self._sockFile);
       }
 
       self.monitor.stop();


### PR DESCRIPTION
Right now fs.unlink is used without a callback. This would throw
from Node.js 10 on. Therefore switch to the sync version. That way
errors are also going to be detected.

See https://github.com/nodejs/node/pull/18668