### PR TITLE
fixed windows issue due to missing callback exception

### DIFF
--- a/lib/forever/worker.js
+++ b/lib/forever/worker.js
@@ -93,7 +93,7 @@ Worker.prototype.start = function (callback) {
         // as a mapping to the `\\.pipe\\*` "files" that can't
         // be enumerated because ... Windows.
         //
-        fs.unlink(self._sockFile);
+        fs.unlinkSync(self._sockFile);
       }
 
       self.monitor.stop();


### PR DESCRIPTION
When running stop on windows the following error was thrown preventing forever from properly stopping the script it started:
```
fs.js:141
    throw new ERR_INVALID_CALLBACK();
    ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:141:11)
    at Object.unlink (fs.js:912:14)
    at exports.NsSocket.<anonymous> (D:\Dump\forever\lib\forever\worker.js:96:12)
    at exports.NsSocket.EventEmitter.emit (D:\Dump\forever\node_modules\eventemitter2\lib\eventemitter2.js:339:22)
    at exports.NsSocket._onData (D:\Dump\forever\node_modules\nssocket\lib\nssocket.js:456:8)
    at Lazy.<anonymous> (D:\Dump\forever\node_modules\lazy\lazy.js:91:13)
    at Lazy.<anonymous> (D:\Dump\forever\node_modules\lazy\lazy.js:73:19)
    at Lazy.emit (events.js:182:13)
    at Lazy.<anonymous> (D:\Dump\forever\node_modules\lazy\lazy.js:74:22)
    at Lazy.emit (events.js:182:13)
```

This PR will resolve this the issue