### PR TITLE
Remove dependency on timespan

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,6 +11,7 @@
   "prototypejs": false,
   "mootools": false,
   "dojo": false,
+  "esversion": 5,
 
   "devel": true,
 

--- a/lib/forever.js
+++ b/lib/forever.js
@@ -14,7 +14,6 @@ var fs = require('fs'),
     cliff = require('cliff'),
     nconf = require('nconf'),
     nssocket = require('nssocket'),
-    timespan = require('timespan'),
     utile = require('utile'),
     winston = require('winston'),
     mkdirp = utile.mkdirp,
@@ -1037,7 +1036,20 @@ forever.columns = {
   uptime: {
     color: 'yellow',
     get: function (proc) {
-      return proc.running ? timespan.fromDates(new Date(proc.ctime), new Date()).toString().yellow : "STOPPED".red;
+      if (!proc.running) {
+        return "STOPPED".red;
+      }
+
+      var delta = (new Date().getTime() - proc.ctime) / 1000;
+      var days = Math.floor(delta / 86400);
+      delta -= days * 86400;
+      var hours = Math.floor(delta / 3600) % 24;
+      delta -= hours * 3600;
+      var minutes = Math.floor(delta / 60) % 60;
+      delta -= minutes * 60;
+      var seconds = delta % 60;
+
+      return (days+':'+hours+':'+minutes+':'+seconds).yellow;
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "path-is-absolute": "~1.0.0",
     "prettyjson": "^1.1.2",
     "shush": "^1.0.0",
-    "timespan": "~2.3.0",
     "utile": "~0.2.1",
     "winston": "~0.8.1"
   },
   "devDependencies": {
     "broadway": "~0.3.6",
     "eventemitter2": "0.4.x",
+    "moment": "^2.23.0",
     "request": "2.x.x",
     "vows": "0.7.x"
   },

--- a/test/core/uptime-test.js
+++ b/test/core/uptime-test.js
@@ -9,7 +9,7 @@ vows.describe('forever/core/uptime').addBatch({
       "for not running process correctly": function (err, procs) {
         assert.equal(forever.columns.uptime.get({}), 'STOPPED'.red);
       },
-      "calculates uptime for running process correctly": function (err, procs) {
+      "for running process correctly": function (err, procs) {
         var launchTime = moment.utc()
           .subtract(4000, 'days')
           .subtract(6, 'hours')

--- a/test/core/uptime-test.js
+++ b/test/core/uptime-test.js
@@ -1,0 +1,28 @@
+var assert = require('assert'),
+  vows = require('vows'),
+  moment = require('moment'),
+  forever = require('../../lib/forever');
+
+vows.describe('forever/core/uptime').addBatch({
+  "When using forever" : {
+    "calculates uptime" : {
+      "for not running process correctly": function (err, procs) {
+        assert.equal(forever.columns.uptime.get({}), 'STOPPED'.red);
+      },
+      "calculates uptime for running process correctly": function (err, procs) {
+        var launchTime = moment.utc()
+          .subtract(4000, 'days')
+          .subtract(6, 'hours')
+          .subtract(8, 'minutes')
+          .subtract(25, 'seconds');
+
+        var timeWithoutMsecs = forever.columns.uptime.get({
+          running: true,
+          ctime: launchTime.toDate().getTime()
+        }).strip.split('.')[0];
+
+        assert.equal(timeWithoutMsecs, '4000:6:8:25');
+      }
+    }
+  }
+}).export(module);


### PR DESCRIPTION
Inspired by https://github.com/foreverjs/forever/pull/956 
Addresses https://nodesecurity.io/advisories/533

Implemented differently due to following concerns:

1) `date-difference` is not a widely used library, so I am wary to include it as a dependency in a major project;
2) Alternative solution based on moment.js does not support uptime > 365 days correctly (which is a long-shot but hey, that happens).

This PR does not change the original signature of an uptime.