### PR TITLE
Add --skipIgnoreFile argument

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -64,6 +64,7 @@ var help = [
   '  --spinSleepTime  Time to wait (millis) between launches of a spinning script.',
   '  --colors         --no-colors will disable output coloring',
   '  --plain          alias of --no-colors',
+  '  --skipIgnoreFile Don\'t attempt to read .foreverignore file',
   '  -d, --debug      Forces forever to log debug output',
   '  -v, --verbose    Turns on the verbose messages from Forever',
   '  -s, --silent     Run the child script silencing stdout and stderr',
@@ -107,23 +108,24 @@ var actions = [
 ];
 
 var argvOptions = cli.argvOptions = {
-  'command':   {alias: 'c'},
-  'errFile':   {alias: 'e'},
-  'logFile':   {alias: 'l'},
-  'killTree':  {alias: 't', boolean: true},
-  'append':    {alias: 'a', boolean: true},
-  'fifo':      {alias: 'f', boolean: true},
-  'number':    {alias: 'n'},
-  'max':       {alias: 'm'},
-  'outFile':   {alias: 'o'},
-  'path':      {alias: 'p'},
-  'help':      {alias: 'h'},
-  'silent':    {alias: 's', boolean: true},
-  'verbose':   {alias: 'v', boolean: true},
-  'watch':     {alias: 'w', boolean: true},
-  'debug':     {alias: 'd', boolean: true},
-  'plain':     {boolean: true},
-  'uid':       {alias: 'u'}
+  'command':        {alias: 'c'},
+  'errFile':        {alias: 'e'},
+  'logFile':        {alias: 'l'},
+  'killTree':       {alias: 't', boolean: true},
+  'append':         {alias: 'a', boolean: true},
+  'fifo':           {alias: 'f', boolean: true},
+  'number':         {alias: 'n'},
+  'max':            {alias: 'm'},
+  'outFile':        {alias: 'o'},
+  'path':           {alias: 'p'},
+  'help':           {alias: 'h'},
+  'silent':         {alias: 's', boolean: true},
+  'skipIgnoreFile': {boolean: false},
+  'verbose':        {alias: 'v', boolean: true},
+  'watch':          {alias: 'w', boolean: true},
+  'debug':          {alias: 'd', boolean: true},
+  'plain':          {boolean: true},
+  'uid':            {alias: 'u'}
 };
 
 app.use(flatiron.plugins.cli, {
@@ -206,7 +208,7 @@ var getOptions = cli.getOptions = function (file) {
       absFile = isAbsolute(file) ? file : path.resolve(process.cwd(), file),
       configKeys = [
         'pidFile', 'logFile', 'errFile', 'watch', 'minUptime', 'append',
-        'silent', 'outFile', 'max', 'command', 'path', 'spinSleepTime',
+        'silent', 'skipIgnoreFile', 'outFile', 'max', 'command', 'path', 'spinSleepTime',
         'sourceDir', 'workingDir', 'uid', 'watchDirectory', 'watchIgnore',
         'killTree', 'killSignal', 'id'
       ],


### PR DESCRIPTION
As discussed in #1024, when I run `forever -w script.js` it prints an error:
```
error: Could not read .foreverignore file.
error: ENOENT: no such file or directory, open '/home/dev/code/script/.foreverignore'
```
This patch adds a `--skipIgnoreFile` command-line argument to skip trying to read .foreverignore file and thus generating no error:
`forever --skipIgnoreFile -w check_changes.js`

This patch depends on https://github.com/foreverjs/forever-monitor/pull/166